### PR TITLE
feat: 添加多格式导出功能并支持结构预览

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ AIwork4translator 是一个专为技术文档设计的翻译工具。通过**Aho
   - **CLI**：偏好记忆、极简操作。
   - **WebUI**：双栏实时预览、所见即所得。
 - **📄 多格式支持**：原生支持 Markdown，集成 [MarkItDown](https://github.com/microsoft/markitdown) 支持 PDF/Word/Excel 等格式转换。
+- **📦 多格式导出**：翻译完成后可基于 `_intermediate.json` 一键导出 `docx/pdf/epub/xlsx`，便于分发与排版复用。
 
 ---
 
@@ -77,6 +78,21 @@ CLI 版本专注于效率，适合批量处理和大文件翻译。
     *   **无词表**：输入 `n`，程序可生成空白词表（*功能调整中*）。
     *   **有词表**：输入 `y` 并提供 CSV 路径。翻译结束后，可选择是否将新发现的术语合并回原表。
 4.  **非 MD 文件**：程序会自动调用 MarkItDown 转换为 Markdown，转换后需用户确认继续。
+5.  **导出文件**：翻译结束后可按提示选择导出格式（`docx/pdf/epub/xlsx`）。导出以 `_intermediate.json` 为输入源，通常可在不重新翻译的情况下重复导出以调整排版。
+
+### 导出与预览（脚本）
+
+如果你已经有导出的文件（`.docx/.pdf/.epub`），可以用脚本快速查看它们的结构（标题/目录/第一页文本抽取）：
+
+```bash
+uv run python scripts/preview_export_outputs.py "<导出文件的基础路径（不带扩展名）>"
+```
+
+示例：
+
+```bash
+uv run python scripts/preview_export_outputs.py "input_files/《赤红传说》112-127"
+```
 
 ### WebUI 版本
 

--- a/devdiary.md
+++ b/devdiary.md
@@ -227,3 +227,19 @@
   - 各 Provider 的返回值格式保持一致：`(content, total_tokens)`。
 - **文件修改**：
   - `modules/api_tool.py`: 为各 Provider 增加异步 client 与异步生成方法。
+
+### 2026/03/14 - 多格式导出与结构预览：基于 `_intermediate.json`
+- **背景**：翻译完成后需要直接生成可分发的文档（Word/PDF/EPUB/Excel），并能快速检查导出结果的结构是否正确（标题层级/目录/正文）。
+- **核心变更**：
+  - 以 `_intermediate.json` 为单一数据源实现导出，避免对 Markdown 进行二次解析导致结构丢失。
+  - 导出模块统一按 Markdown 标题语法（`#`-`######`）识别并重建结构：
+    - DOCX：标题写入为 Heading，正文按段落写入；Notes 以灰色斜体追加。
+    - EPUB：按一级标题拆分章节并生成目录（TOC），正文段落换行保留为 `<br/>`。
+    - PDF：改用 ReportLab 直出（避免 CJK 字体在 xhtml2pdf 中不稳定），嵌入系统中文字体后中文可正常显示与文本抽取。
+  - 新增结构预览脚本：输出 DOCX 标题、EPUB 目录，以及 PDF 第 1 页文本抽取，便于快速人工验收。
+- **文件修改/新增**：
+  - `modules/export_tool.py`
+  - `scripts/preview_export_outputs.py`
+- **验证与结果**：
+  - 测试：`uv run pytest -q tests/test_export.py` 通过。
+  - 实测：对 `input_files/《赤红传说》112-127_intermediate.json` 导出 `docx/pdf/epub`，预览脚本可正确展示 DOCX 标题、EPUB 目录，且 PDF 中文文本抽取正常。

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from modules.write_out_tool import write_to_markdown, write_to_markdown_through_
 from modules.markitdown_tool import markitdown_tool
 from modules.count_tool import count_md_words, count_structured_paragraphs
 from modules.translation_core import TranslationCore, TranslationResult, TerminologyPolicy
+from modules.export_tool import export_json_to_xlsx, export_json_to_docx, export_json_to_pdf, export_json_to_epub
 from services.diagnostics import global_diagnostics
 
 @dataclass
@@ -368,6 +369,9 @@ def run_sync_translation_loop(config: UserConfig, translation_core: TranslationC
     # 如果是 generator (read_structured_paragraphs 返回 generator)，需要小心
     # config.paragraphs 在非并发模式下是 generator
     
+    # Collection for export
+    completed_paragraphs = []
+    
     for segment in iterator:
         current_paragraph += 1
         print(f"开始翻译段落【{current_paragraph}】/【{config.total_paragraphs}】")
@@ -422,6 +426,18 @@ def run_sync_translation_loop(config: UserConfig, translation_core: TranslationC
                     response_text += f"\n\n---\n\n{result.notes}\n"
                 print(response_text)
                 
+                # 收集用于 JSON 导出的数据
+                completed_paragraphs.append({
+                    'paragraph_number': current_paragraph,
+                    'meta_data': meta_data,
+                    'content': paragraph_text,
+                    'translation': result.content,
+                    'notes': result.notes,
+                    'new_terms': result.new_terms_delta,
+                    'matched_terms': result.matched_terms_delta,
+                    'status': 'completed'
+                })
+                
                 # 写出
                 mode = 'structured' if config.preserve_structure else 'flat'
                 write_to_markdown(config.output_md_file, (response_text, meta_data), mode) # type: ignore
@@ -463,6 +479,17 @@ def run_sync_translation_loop(config: UserConfig, translation_core: TranslationC
                     print("正在重试当前段落...")
                     time.sleep(1) # Backoff
 
+    # Save JSON for Sync Mode
+    if not config.json_path:
+        config.json_path = os.path.join(config.input_dir, f"{config.base_name}_intermediate.json")
+    
+    try:
+        with open(config.json_path, 'w', encoding='utf-8') as f:
+            json.dump({'text_info': completed_paragraphs}, f, ensure_ascii=False, indent=2)
+        print(f"中间 JSON 文件已保存至: {config.json_path}")
+    except Exception as e:
+        print(f"保存中间 JSON 失败: {e}")
+
     return total_token
 
 def save_untranslated(input_md_file, input_dir, base_name, last_text=None):
@@ -481,6 +508,76 @@ def save_untranslated(input_md_file, input_dir, base_name, last_text=None):
             print(f"未翻译部分已保存至：{untranslated_path}")
     except Exception as e:
         print(f"保存未翻译部分失败: {e}")
+
+def handle_export(config: UserConfig):
+    if not config.json_path or not os.path.exists(config.json_path):
+        print("未找到中间 JSON 文件，无法进行格式转换导出。")
+        return
+
+    print("\n--------------------------------------------------")
+    print("翻译已完成。是否需要将结果导出为其他格式？")
+    print("支持格式：DOCX, PDF, EPUB, XLSX")
+    print("--------------------------------------------------")
+    
+    while True:
+        choice = input("是否导出？(y/n): ").strip().lower()
+        if choice == 'n':
+            return
+        elif choice == 'y':
+            break
+        else:
+            print("请输入 y 或 n")
+    
+    print("\n请选择导出格式（输入数字，多选可用逗号分隔，如 1,4）：")
+    print("1. DOCX (Word 文档)")
+    print("2. PDF (便携式文档)")
+    print("3. EPUB (电子书)")
+    print("4. XLSX (Excel 表格)")
+    print("5. 全部导出")
+    
+    choices = input("请输入选项: ").strip()
+    selected = set()
+    
+    if '5' in choices or 'all' in choices.lower():
+        selected = {1, 2, 3, 4}
+    else:
+        parts = choices.replace('，', ',').split(',')
+        for p in parts:
+            p = p.strip()
+            if p in ('1', '2', '3', '4'):
+                selected.add(int(p))
+    
+    if not selected:
+        print("未选择有效格式，跳过导出。")
+        return
+
+    base_path = os.path.splitext(config.output_md_file)[0]
+    
+    if 1 in selected:
+        print("正在导出 DOCX ...")
+        out_path = f"{base_path}.docx"
+        if export_json_to_docx(config.json_path, out_path):
+            print(f"DOCX 导出成功: {out_path}")
+            
+    if 2 in selected:
+        print("正在导出 PDF ...")
+        out_path = f"{base_path}.pdf"
+        if export_json_to_pdf(config.json_path, out_path):
+            print(f"PDF 导出成功: {out_path}")
+
+    if 3 in selected:
+        print("正在导出 EPUB ...")
+        out_path = f"{base_path}.epub"
+        if export_json_to_epub(config.json_path, out_path):
+            print(f"EPUB 导出成功: {out_path}")
+
+    if 4 in selected:
+        print("正在导出 XLSX ...")
+        out_path = f"{base_path}.xlsx"
+        if export_json_to_xlsx(config.json_path, out_path):
+            print(f"XLSX 导出成功: {out_path}")
+            
+    print("导出流程结束。")
 
 def finalize_process(config: UserConfig, total_token, start_time, glossary_df, aggregated_new_terms):
     end_time = perf_counter()
@@ -557,6 +654,8 @@ def main():
             )
             
         finalize_process(config, total_token, start_time, glossary_df, aggregated_new_terms)
+        
+        handle_export(config)
         
     except KeyboardInterrupt:
         print("\n任务已中断，开始保存累积的术语表……")

--- a/modules/export_tool.py
+++ b/modules/export_tool.py
@@ -1,0 +1,260 @@
+import json
+import os
+import re
+import html
+from typing import List, Dict, Any
+import pandas as pd
+from docx import Document
+from docx.shared import RGBColor
+from xhtml2pdf import pisa
+from ebooklib import epub
+
+def _load_json_data(json_path: str) -> List[Dict[str, Any]]:
+    with open(json_path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    return data.get('text_info', [])
+
+def _iter_markdown_blocks(text: str):
+    lines = (text or "").replace("\r\n", "\n").replace("\r", "\n").split("\n")
+    buffer: List[str] = []
+    for line in lines:
+        m = re.match(r"^(#{1,6})\s+(.+?)\s*$", line)
+        if m:
+            paragraph_text = "\n".join(buffer).strip()
+            if paragraph_text:
+                for p in paragraph_text.split("\n\n"):
+                    p = p.strip()
+                    if p:
+                        yield ("para", p)
+            buffer = []
+            yield ("heading", len(m.group(1)), m.group(2).strip())
+        else:
+            buffer.append(line)
+
+    paragraph_text = "\n".join(buffer).strip()
+    if paragraph_text:
+        for p in paragraph_text.split("\n\n"):
+            p = p.strip()
+            if p:
+                yield ("para", p)
+
+def export_json_to_xlsx(json_path: str, output_path: str) -> bool:
+    try:
+        data = _load_json_data(json_path)
+        rows = []
+        for item in data:
+            rows.append({
+                'ID': item.get('paragraph_number'),
+                'Source': item.get('content'),
+                'Translation': item.get('translation'),
+                'Notes': item.get('notes'),
+                'Header Path': " > ".join(item.get('meta_data', {}).get('header_path', []) or []) if item.get('meta_data') else ""
+            })
+        
+        df = pd.DataFrame(rows)
+        df.to_excel(output_path, index=False)
+        return True
+    except Exception as e:
+        print(f"[Error] Export to XLSX failed: {e}")
+        return False
+
+def export_json_to_docx(json_path: str, output_path: str) -> bool:
+    try:
+        data = _load_json_data(json_path)
+        doc = Document()
+        
+        # Add Title
+        base_name = os.path.splitext(os.path.basename(json_path))[0].replace('_intermediate', '')
+        doc.add_heading(base_name, 0)
+        
+        for item in data:
+            content = item.get('translation', '') or ''
+            notes = item.get('notes', '')
+
+            for block in _iter_markdown_blocks(content):
+                if block[0] == "heading":
+                    _, level, title = block
+                    doc.add_heading(title, level=min(int(level), 9))
+                else:
+                    _, para = block
+                    doc.add_paragraph(para)
+            
+            # Handle Notes
+            if notes:
+                p_note = doc.add_paragraph()
+                run = p_note.add_run(f"Note: {notes}")
+                run.italic = True
+                run.font.color.rgb = RGBColor(100, 100, 100) # Gray
+        
+        doc.save(output_path)
+        return True
+    except Exception as e:
+        print(f"[Error] Export to DOCX failed: {e}")
+        return False
+
+def export_json_to_pdf(json_path: str, output_path: str) -> bool:
+    try:
+        data = _load_json_data(json_path)
+        from reportlab.lib.pagesizes import A4
+        from reportlab.lib.units import mm
+        from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+        from reportlab.pdfbase import pdfmetrics
+        from reportlab.pdfbase.ttfonts import TTFont
+        from reportlab.platypus import SimpleDocTemplate, Paragraph
+
+        fonts = [
+            ("SimHei", "C:\\Windows\\Fonts\\simhei.ttf"),
+            ("Microsoft YaHei", "C:\\Windows\\Fonts\\msyh.ttf"),
+            ("Arial Unicode MS", "C:\\Windows\\Fonts\\ARIALUNI.TTF"),
+        ]
+
+        font_name = "Helvetica"
+        for _, path in fonts:
+            if os.path.exists(path) and path.lower().endswith(".ttf"):
+                try:
+                    pdfmetrics.registerFont(TTFont("CJKFont", path))
+                    font_name = "CJKFont"
+                    break
+                except Exception as e:
+                    print(f"[Warning] Failed to register PDF font: {e}")
+
+        styles = getSampleStyleSheet()
+        base_style = ParagraphStyle(
+            name="Base",
+            parent=styles["Normal"],
+            fontName=font_name,
+            fontSize=10.5,
+            leading=14,
+            spaceAfter=6,
+        )
+        note_style = ParagraphStyle(
+            name="Note",
+            parent=base_style,
+            fontSize=9,
+            leading=12,
+            textColor="#666666",
+        )
+        heading_styles = {}
+        for level, size in [(1, 18), (2, 15), (3, 13), (4, 12), (5, 11), (6, 10.5)]:
+            heading_styles[level] = ParagraphStyle(
+                name=f"H{level}",
+                parent=base_style,
+                fontSize=size,
+                leading=max(int(size * 1.2), 12),
+                spaceBefore=10,
+                spaceAfter=6,
+            )
+
+        doc = SimpleDocTemplate(
+            output_path,
+            pagesize=A4,
+            leftMargin=20 * mm,
+            rightMargin=20 * mm,
+            topMargin=18 * mm,
+            bottomMargin=18 * mm,
+            title=os.path.splitext(os.path.basename(output_path))[0],
+        )
+
+        story = []
+        for item in data:
+            content = item.get("translation", "") or ""
+            notes = item.get("notes", "") or ""
+
+            for block in _iter_markdown_blocks(content):
+                if block[0] == "heading":
+                    _, level, title = block
+                    level = min(int(level), 6)
+                    story.append(Paragraph(html.escape(title), heading_styles[level]))
+                else:
+                    _, para = block
+                    para_html = html.escape(para).replace("\n", "<br/>")
+                    story.append(Paragraph(para_html, base_style))
+
+            if notes:
+                story.append(Paragraph(f"Note: {html.escape(notes)}", note_style))
+
+        if not story:
+            story.append(Paragraph("(empty)", base_style))
+
+        doc.build(story)
+        return True
+    except Exception as e:
+        print(f"[Error] Export to PDF failed: {e}")
+        return False
+
+def export_json_to_epub(json_path: str, output_path: str) -> bool:
+    try:
+        data = _load_json_data(json_path)
+        base_name = os.path.splitext(os.path.basename(json_path))[0].replace('_intermediate', '')
+        
+        book = epub.EpubBook()
+        book.set_identifier(f'id_{base_name}')
+        book.set_title(base_name)
+        book.set_language('zh')
+        book.add_author('Program Translator')
+        
+        chapters = []
+        chapter_count = 1
+        current_chapter = epub.EpubHtml(title='Introduction', file_name='intro.xhtml', lang='zh')
+        chapter_content = "<h1>Start</h1>"
+
+        for item in data:
+            content = item.get('translation', '') or ''
+            notes = item.get('notes', '')
+
+            for block in _iter_markdown_blocks(content):
+                if block[0] == "heading":
+                    _, level, title = block
+                    level = int(level)
+                    title_html = html.escape(title)
+                    if level == 1:
+                        if current_chapter:
+                            current_chapter.content = chapter_content
+                            book.add_item(current_chapter)
+                            chapters.append(current_chapter)
+
+                        current_chapter = epub.EpubHtml(
+                            title=title,
+                            file_name=f'chap_{chapter_count}.xhtml',
+                            lang='zh',
+                        )
+                        chapter_count += 1
+                        chapter_content = f"<h1>{title_html}</h1>\n"
+                    else:
+                        h_level = min(level, 6)
+                        chapter_content += f"<h{h_level}>{title_html}</h{h_level}>\n"
+                else:
+                    _, para = block
+                    para_html = html.escape(para).replace("\n", "<br/>")
+                    chapter_content += f"<p>{para_html}</p>\n"
+            
+            if notes:
+                chapter_content += f"<p style='color:gray; font-style:italic;'>Note: {html.escape(notes)}</p>\n"
+        
+        # Save last chapter
+        if current_chapter:
+            current_chapter.content = chapter_content
+            book.add_item(current_chapter)
+            chapters.append(current_chapter)
+        
+        # Define Table of Contents
+        book.toc = tuple(chapters)
+        
+        # Add default NCX and Nav file
+        book.add_item(epub.EpubNcx())
+        book.add_item(epub.EpubNav())
+        
+        # Define CSS style
+        style = 'body { font-family: sans-serif; }'
+        nav_css = epub.EpubItem(uid="style_nav", file_name="style/nav.css", media_type="text/css", content=style)
+        book.add_item(nav_css)
+        
+        # Basic spine
+        book.spine = ['nav'] + chapters
+        
+        epub.write_epub(output_path, book, {})
+        return True
+        
+    except Exception as e:
+        print(f"[Error] Export to EPUB failed: {e}")
+        return False

--- a/program_translator.egg-info/PKG-INFO
+++ b/program_translator.egg-info/PKG-INFO
@@ -83,4 +83,7 @@ Requires-Dist: google-genai>=1.52.0
 Requires-Dist: pyahocorasick>=2.2.0
 Requires-Dist: openpyxl>=3.1.5
 Requires-Dist: pytest-asyncio>=1.3.0
+Requires-Dist: python-docx>=1.2.0
+Requires-Dist: xhtml2pdf>=0.2.17
+Requires-Dist: ebooklib>=0.20
 Dynamic: license-file

--- a/program_translator.egg-info/SOURCES.txt
+++ b/program_translator.egg-info/SOURCES.txt
@@ -6,6 +6,7 @@ modules/api_tool.py
 modules/config.py
 modules/count_tool.py
 modules/csv_process_tool.py
+modules/log_manager.py
 modules/markitdown_tool.py
 modules/read_tool.py
 modules/terminology_tool.py
@@ -23,8 +24,11 @@ tests/test_api_direct.py
 tests/test_api_parser.py
 tests/test_api_providers.py
 tests/test_concurrency_flow.py
+tests/test_finalize_flow.py
 tests/test_get_valid_path.py
 tests/test_join_and_write.py
+tests/test_log_manager.py
+tests/test_main_replay.py
 tests/test_markitdown_tool_title.py
 tests/test_matching_terms.py
 tests/test_matching_terms_aho.py

--- a/program_translator.egg-info/requires.txt
+++ b/program_translator.egg-info/requires.txt
@@ -76,3 +76,6 @@ google-genai>=1.52.0
 pyahocorasick>=2.2.0
 openpyxl>=3.1.5
 pytest-asyncio>=1.3.0
+python-docx>=1.2.0
+xhtml2pdf>=0.2.17
+ebooklib>=0.20

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,9 @@ dependencies = [
     "pyahocorasick>=2.2.0",
     "openpyxl>=3.1.5",
     "pytest-asyncio>=1.3.0",
+    "python-docx>=1.2.0",
+    "xhtml2pdf>=0.2.17",
+    "ebooklib>=0.20",
 ]
 
 [tool.uv]

--- a/scripts/check_openai_client.py
+++ b/scripts/check_openai_client.py
@@ -1,0 +1,30 @@
+from openai import OpenAI, AsyncOpenAI
+import asyncio
+
+async def check_async():
+    try:
+        client = AsyncOpenAI(api_key='test')
+        print(f"Async Has responses attribute: {hasattr(client, 'responses')}")
+        if hasattr(client, 'responses'):
+            print(f"Async responses type: {type(client.responses)}")
+            # Note: Async resource usually has methods that return coroutines
+            print(f"Async Has parse: {hasattr(client.responses, 'parse')}")
+            
+        print(f"Async Has chat attribute: {hasattr(client, 'chat')}")
+        if hasattr(client, 'chat'):
+            print(f"Async Has completions: {hasattr(client.chat, 'completions')}")
+            if hasattr(client.chat.completions, 'create'):
+                print("Async Has create: True")
+    except Exception as e:
+        print(f"Async Error: {e}")
+
+if __name__ == "__main__":
+    try:
+        # Check Sync (Already done, but for completeness)
+        client = OpenAI(api_key='test')
+        print(f"Sync Has responses attribute: {hasattr(client, 'responses')}")
+        
+        # Check Async
+        asyncio.run(check_async())
+    except Exception as e:
+        print(f"Error: {e}")

--- a/scripts/inspect_gemini.py
+++ b/scripts/inspect_gemini.py
@@ -1,0 +1,11 @@
+from google import genai
+print("genai attributes:", dir(genai))
+if hasattr(genai, 'Client'):
+    print("Client attributes:", dir(genai.Client))
+    client = genai.Client(api_key='test')
+    print("Instance attributes:", dir(client))
+    if hasattr(client, 'models'):
+        print("client.models attributes:", dir(client.models))
+    if hasattr(client, 'aio'):
+        print("client.aio exists!")
+        print("client.aio attributes:", dir(client.aio))

--- a/scripts/inspect_gemini_async.py
+++ b/scripts/inspect_gemini_async.py
@@ -1,0 +1,12 @@
+from google import genai
+import asyncio
+
+async def inspect_async():
+    client = genai.Client(api_key='test')
+    if hasattr(client, 'aio'):
+        print("client.aio.models attributes:", dir(client.aio.models))
+        if hasattr(client.aio.models, 'generate_content'):
+            print("Has generate_content in aio.models!")
+
+if __name__ == "__main__":
+    asyncio.run(inspect_async())

--- a/scripts/preview_export_outputs.py
+++ b/scripts/preview_export_outputs.py
@@ -1,0 +1,94 @@
+import os
+import sys
+
+from docx import Document
+from ebooklib import epub
+from pypdf import PdfReader
+
+
+def _print_docx_preview(docx_path: str) -> None:
+    print("\n--- DOCX headings (first 30) ---")
+    d = Document(docx_path)
+    headings = []
+    for p in d.paragraphs:
+        style_name = p.style.name if p.style else ""
+        text = (p.text or "").strip()
+        if text and style_name.lower().startswith("heading"):
+            headings.append(f"{style_name}: {text}")
+        if len(headings) >= 30:
+            break
+    print("\n".join(headings) if headings else "(no headings found)")
+
+    print("\n--- DOCX sample paragraphs (first 8 non-empty) ---")
+    sample = []
+    for p in d.paragraphs:
+        text = (p.text or "").strip()
+        if text:
+            sample.append(text)
+        if len(sample) >= 8:
+            break
+    for t in sample:
+        print(f"- {t[:200]}")
+
+
+def _print_epub_preview(epub_path: str) -> None:
+    print("\n--- EPUB toc (first 30) ---")
+    book = epub.read_epub(epub_path)
+    stack = [book.toc]
+    titles = []
+    while stack:
+        node = stack.pop(0)
+        if isinstance(node, (list, tuple)):
+            stack[0:0] = list(node)
+            continue
+        title = getattr(node, "title", None)
+        if title:
+            titles.append(str(title))
+    print("\n".join(titles[:30]) if titles else "(toc empty)")
+
+
+def _print_pdf_preview(pdf_path: str) -> None:
+    print("\n--- PDF text extract (page 1, first 800 chars) ---")
+    reader = PdfReader(pdf_path)
+    if not reader.pages:
+        print("(no pages)")
+        return
+    text = (reader.pages[0].extract_text() or "").replace("\r", "\n")
+    print(text[:800])
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("Usage: uv run python scripts/preview_export_outputs.py <base_path_without_ext>")
+        return 2
+
+    base = sys.argv[1]
+    docx_path = base + ".docx"
+    pdf_path = base + ".pdf"
+    epub_path = base + ".epub"
+
+    missing = [p for p in [docx_path, pdf_path, epub_path] if not os.path.exists(p)]
+    if missing:
+        print("Missing files:")
+        for p in missing:
+            print(f"- {p}")
+        return 1
+
+    print(
+        "SIZES(bytes):",
+        {
+            "docx": os.path.getsize(docx_path),
+            "pdf": os.path.getsize(pdf_path),
+            "epub": os.path.getsize(epub_path),
+        },
+    )
+
+    _print_docx_preview(docx_path)
+    _print_epub_preview(epub_path)
+    _print_pdf_preview(pdf_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/scripts/test_async_compatibility.py
+++ b/scripts/test_async_compatibility.py
@@ -1,0 +1,137 @@
+import asyncio
+import os
+import json
+from typing import Dict, Any, List
+from openai import AsyncOpenAI
+from pydantic import BaseModel
+from dotenv import load_dotenv
+
+# Load environment variables
+load_dotenv(dotenv_path="data/.env")
+
+# --- Mocks & Models for Testing ---
+
+class NewTerm(BaseModel):
+    term: str
+    translation: str
+    reason: str
+
+class TranslationResponseModel(BaseModel):
+    translation: str
+    new_terms: List[NewTerm]
+
+# --- Test Functions ---
+
+async def test_kimi_async():
+    print("\n--- Testing Kimi (Async) ---")
+    base_url = os.getenv('KIMI_BASE_URL') or 'https://api.moonshot.cn/v1'
+    api_key = os.getenv('KIMI_API_KEY')
+    
+    if not api_key:
+        print("Skipping Kimi: No API Key found.")
+        return
+
+    client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+    model = os.getenv('KIMI_MODEL', 'kimi-k2-turbo-preview')
+
+    print(f"Client initialized with URL: {base_url}")
+    
+    try:
+        print("Sending request...")
+        completion = await client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": "You are a translator."},
+                {"role": "user", "content": "Hello, world!"}
+            ],
+            temperature=0.7,
+        )
+        print("Response received:")
+        print(completion.choices[0].message.content)
+    except Exception as e:
+        print(f"Error testing Kimi: {e}")
+
+async def test_doubao_async():
+    print("\n--- Testing Doubao (Async Structured) ---")
+    base_url = os.getenv('DOUBAO_BASE_URL')
+    api_key = os.getenv('DOUBAO_API_KEY')
+    
+    if not api_key or not base_url:
+        print("Skipping Doubao: No API Key or Base URL found.")
+        return
+
+    client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+    model = os.getenv('DOUBAO_MODEL', 'doubao-seed-1-6-251015')
+
+    print(f"Client initialized with URL: {base_url}")
+
+    try:
+        print("Sending request (with client.beta.chat.completions.parse equivalent logic if available)...")
+        # Note: AsyncOpenAI also has .beta.chat.completions.parse
+        # Let's try standard parse if available, or fallback to manual
+        
+        if hasattr(client.beta.chat.completions, 'parse'):
+             print("Using client.beta.chat.completions.parse...")
+             response = await client.beta.chat.completions.parse(
+                model=model,
+                messages=[
+                    {"role": "system", "content": "Translate to Chinese."},
+                    {"role": "user", "content": "Hello, world!"}
+                ],
+                response_format=TranslationResponseModel,
+                extra_body={
+                    "thinking": {"type": "disabled"} 
+                }
+            )
+             print("Response received:")
+             print(response.choices[0].message.parsed)
+        else:
+            print("AsyncOpenAI beta.parse not found, trying raw request with json_schema...")
+            # Fallback test for raw json mode if parse helper is missing
+            completion = await client.chat.completions.create(
+                model=model,
+                messages=[
+                    {"role": "system", "content": "Translate to Chinese. Output JSON."},
+                    {"role": "user", "content": "Hello, world!"}
+                ],
+                response_format={"type": "json_object"}
+            )
+            print("Response received (Raw JSON):")
+            print(completion.choices[0].message.content)
+
+    except Exception as e:
+        print(f"Error testing Doubao: {e}")
+
+async def test_cancellation():
+    print("\n--- Testing Cancellation (Simulated) ---")
+    # Simulate a long running task that gets cancelled
+    try:
+        print("Starting long task...")
+        await asyncio.sleep(5)
+        print("Task finished (Unexpected if cancelled)")
+    except asyncio.CancelledError:
+        print("Task was successfully cancelled!")
+
+async def main():
+    print("Starting Async Compatibility Tests...")
+    
+    # 1. Test Kimi
+    await test_kimi_async()
+    
+    # 2. Test Doubao
+    await test_doubao_async()
+    
+    # 3. Test Cancellation (Simulate Ctrl+C effect)
+    task = asyncio.create_task(test_cancellation())
+    await asyncio.sleep(1)
+    print("Simulating Ctrl+C (Cancelling task)...")
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass # Already handled in task, but await might raise it too
+        
+    print("Tests completed.")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,49 @@
+import os
+import json
+import pytest
+from modules.export_tool import export_json_to_xlsx, export_json_to_docx, export_json_to_pdf, export_json_to_epub
+
+@pytest.fixture
+def dummy_json_path(tmp_path):
+    data = {
+        "text_info": [
+            {
+                "paragraph_number": 1,
+                "meta_data": {"header_path": ["# Chapter 1"], "current_level": 1},
+                "content": "Hello World",
+                "translation": "你好世界",
+                "notes": "Test Note"
+            },
+            {
+                "paragraph_number": 2,
+                "meta_data": {"header_path": ["# Chapter 1", "## Section 1"], "current_level": 2},
+                "content": "This is a test.",
+                "translation": "这是一个测试。",
+                "notes": ""
+            }
+        ]
+    }
+    path = tmp_path / "test_intermediate.json"
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False)
+    return str(path)
+
+def test_export_xlsx(dummy_json_path, tmp_path):
+    output = str(tmp_path / "output.xlsx")
+    assert export_json_to_xlsx(dummy_json_path, output)
+    assert os.path.exists(output)
+
+def test_export_docx(dummy_json_path, tmp_path):
+    output = str(tmp_path / "output.docx")
+    assert export_json_to_docx(dummy_json_path, output)
+    assert os.path.exists(output)
+
+def test_export_pdf(dummy_json_path, tmp_path):
+    output = str(tmp_path / "output.pdf")
+    assert export_json_to_pdf(dummy_json_path, output)
+    assert os.path.exists(output)
+
+def test_export_epub(dummy_json_path, tmp_path):
+    output = str(tmp_path / "output.epub")
+    assert export_json_to_epub(dummy_json_path, output)
+    assert os.path.exists(output)

--- a/uv.lock
+++ b/uv.lock
@@ -31,6 +31,24 @@ wheels = [
 ]
 
 [[package]]
+name = "arabic-reshaper"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/27/9f488e21f87fd8b7ff3b52c372b9510c619ecf1398e4ba30d5f4becc7d86/arabic_reshaper-3.0.0.tar.gz", hash = "sha256:ffcd13ba5ec007db71c072f5b23f420da92ac7f268512065d49e790e62237099", size = 23420, upload-time = "2023-01-10T14:40:00.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/fb/e20b45d81d74d810b01bff408baf8af04abf1d55a1a289c8395ad0919a7c/arabic_reshaper-3.0.0-py3-none-any.whl", hash = "sha256:3f71d5034bb694204a239a6f1ebcf323ac3c5b059de02259235e2016a1a5e2dc", size = 20364, upload-time = "2023-01-10T14:39:58.69Z" },
+]
+
+[[package]]
+name = "asn1crypto"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/cf/d547feed25b5244fcb9392e288ff9fdc3280b10260362fc45d37a798a6ee/asn1crypto-1.5.1.tar.gz", hash = "sha256:13ae38502be632115abf8a24cbe5f4da52e3b5231990aff31123c805306ccb9c", size = 121080, upload-time = "2022-03-15T14:46:52.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/7f/09065fd9e27da0eda08b4d6897f1c13535066174cc023af248fc2a8d5e5a/asn1crypto-1.5.1-py2.py3-none-any.whl", hash = "sha256:db4e40728b728508912cbb3d44f19ce188f218e9eba635821bb4b68564f8fd67", size = 105045, upload-time = "2022-03-15T14:46:51.055Z" },
+]
+
+[[package]]
 name = "azure-ai-documentintelligence"
 version = "1.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -332,6 +350,19 @@ wheels = [
 ]
 
 [[package]]
+name = "cssselect2"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tinycss2" },
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/20/92eaa6b0aec7189fa4b75c890640e076e9e793095721db69c5c81142c2e1/cssselect2-0.9.0.tar.gz", hash = "sha256:759aa22c216326356f65e62e791d66160a0f9c91d1424e8d8adc5e74dddfc6fb", size = 35595, upload-time = "2026-02-12T17:16:39.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/0e/8459ca4413e1a21a06c97d134bfaf18adfd27cea068813dc0faae06cbf00/cssselect2-0.9.0-py3-none-any.whl", hash = "sha256:6a99e5f91f9a016a304dd929b0966ca464bcfda15177b6fb4a118fc0fb5d9563", size = 15453, upload-time = "2026-02-12T17:16:38.317Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -349,6 +380,19 @@ dependencies = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/b7/545d2c10c1fc15e48653c91efde329a790f2eecfbbf2bd16003b5db2bab0/dotenv-0.9.9-py2.py3-none-any.whl", hash = "sha256:29cf74a087b31dafdb5a446b6d7e11cbce8ed2741540e2339c69fbef92c94ce9", size = 1892, upload-time = "2025-02-19T22:15:01.647Z" },
+]
+
+[[package]]
+name = "ebooklib"
+version = "0.20"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/85/322e8882a582d4b707220d1929cfb74c125f2ba513991edbce40dbc462de/ebooklib-0.20.tar.gz", hash = "sha256:35e2f9d7d39907be8d39ae2deb261b19848945903ae3dbb6577b187ead69e985", size = 127066, upload-time = "2025-10-26T20:56:20.968Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/ee/aa015c5de8b0dc42a8e507eae8c2de5d1c0e068c896858fec6d502402ed6/ebooklib-0.20-py3-none-any.whl", hash = "sha256:fff5322517a37e31c972d27be7d982cc3928c16b3dcc5fd7e8f7c0f5d7bcf42b", size = 40995, upload-time = "2025-10-26T20:56:19.104Z" },
 ]
 
 [[package]]
@@ -390,6 +434,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e4/30/eb5dce7994fc71a2f685d98ec33cc660c0a5887db5610137e60d8cbc4489/flatbuffers-25.2.10.tar.gz", hash = "sha256:97e451377a41262f8d9bd4295cc836133415cc03d8cb966410a4af92eb00d26e", size = 22170, upload-time = "2025-02-11T04:26:46.257Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/25/155f9f080d5e4bc0082edfda032ea2bc2b8fab3f4d25d46c1e9dd22a1a89/flatbuffers-25.2.10-py2.py3-none-any.whl", hash = "sha256:ebba5f4d5ea615af3f7fd70fc310636fbb2bbd1f566ac0a23d98dd412de50051", size = 30953, upload-time = "2025-02-11T04:26:44.484Z" },
+]
+
+[[package]]
+name = "freetype-py"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/9c/61ba17f846b922c2d6d101cc886b0e8fb597c109cedfcb39b8c5d2304b54/freetype-py-2.5.1.zip", hash = "sha256:cfe2686a174d0dd3d71a9d8ee9bf6a2c23f5872385cf8ce9f24af83d076e2fbd", size = 851738, upload-time = "2024-08-29T18:32:26.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/a8/258dd138ebe60c79cd8cfaa6d021599208a33f0175a5e29b01f60c9ab2c7/freetype_py-2.5.1-py3-none-macosx_10_9_universal2.whl", hash = "sha256:d01ded2557694f06aa0413f3400c0c0b2b5ebcaabeef7aaf3d756be44f51e90b", size = 1747885, upload-time = "2024-08-29T18:32:17.604Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/93/280ad06dc944e40789b0a641492321a2792db82edda485369cbc59d14366/freetype_py-2.5.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d2f6b3d68496797da23204b3b9c4e77e67559c80390fc0dc8b3f454ae1cd819", size = 1051055, upload-time = "2024-08-29T18:32:19.153Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/853cad240ec63e21a37a512ee19c896b655ce1772d803a3dd80fccfe63fe/freetype_py-2.5.1-py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:289b443547e03a4f85302e3ac91376838e0d11636050166662a4f75e3087ed0b", size = 1043856, upload-time = "2024-08-29T18:32:20.565Z" },
+    { url = "https://files.pythonhosted.org/packages/93/6f/fcc1789e42b8c6617c3112196d68e87bfe7d957d80812d3c24d639782dcb/freetype_py-2.5.1-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:cd3bfdbb7e1a84818cfbc8025fca3096f4f2afcd5d4641184bf0a3a2e6f97bbf", size = 1108180, upload-time = "2024-08-29T18:32:21.871Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/1b/161d3a6244b8a820aef188e4397a750d4a8196316809576d015f26594296/freetype_py-2.5.1-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:3c1aefc4f0d5b7425f014daccc5fdc7c6f914fb7d6a695cc684f1c09cd8c1660", size = 1106792, upload-time = "2024-08-29T18:32:23.134Z" },
+    { url = "https://files.pythonhosted.org/packages/93/6e/bd7fbfacca077bc6f34f1a1109800a2c41ab50f4704d3a0507ba41009915/freetype_py-2.5.1-py3-none-win_amd64.whl", hash = "sha256:0b7f8e0342779f65ca13ef8bc103938366fecade23e6bb37cb671c2b8ad7f124", size = 814608, upload-time = "2024-08-29T18:32:24.648Z" },
 ]
 
 [[package]]
@@ -441,6 +499,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "html5lib"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/b6/b55c3f49042f1df3dcd422b7f224f939892ee94f22abcf503a9b7339eaf2/html5lib-1.1.tar.gz", hash = "sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f", size = 272215, upload-time = "2020-06-22T23:32:38.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/dd/a834df6482147d48e225a49515aabc28974ad5a4ca3215c18a882565b028/html5lib-1.1-py2.py3-none-any.whl", hash = "sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d", size = 112173, upload-time = "2020-06-22T23:32:36.781Z" },
 ]
 
 [[package]]
@@ -1024,6 +1095,18 @@ wheels = [
 ]
 
 [[package]]
+name = "oscrypto"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asn1crypto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/81/a7654e654a4b30eda06ef9ad8c1b45d1534bfd10b5c045d0c0f6b16fecd2/oscrypto-1.3.0.tar.gz", hash = "sha256:6f5fef59cb5b3708321db7cca56aed8ad7e662853351e7991fcf60ec606d47a4", size = 184590, upload-time = "2022-03-18T01:53:26.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/7c/fa07d3da2b6253eb8474be16eab2eadf670460e364ccc895ca7ff388ee30/oscrypto-1.3.0-py2.py3-none-any.whl", hash = "sha256:2b2f1d2d42ec152ca90ccb5682f3e051fb55986e1b170ebde472b133713e7085", size = 194553, upload-time = "2022-03-18T01:53:24.559Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1211,6 +1294,7 @@ dependencies = [
     { name = "cryptography" },
     { name = "distro" },
     { name = "dotenv" },
+    { name = "ebooklib" },
     { name = "fastapi" },
     { name = "filelock" },
     { name = "flatbuffers" },
@@ -1256,6 +1340,7 @@ dependencies = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "python-dateutil" },
+    { name = "python-docx" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "pytz" },
@@ -1274,6 +1359,7 @@ dependencies = [
     { name = "tzdata" },
     { name = "urllib3" },
     { name = "uvicorn" },
+    { name = "xhtml2pdf" },
 ]
 
 [package.metadata]
@@ -1293,6 +1379,7 @@ requires-dist = [
     { name = "cryptography", specifier = "==46.0.3" },
     { name = "distro", specifier = "==1.9.0" },
     { name = "dotenv", specifier = "==0.9.9" },
+    { name = "ebooklib", specifier = ">=0.20" },
     { name = "fastapi", specifier = "==0.115.12" },
     { name = "filelock", specifier = "==3.19.1" },
     { name = "flatbuffers", specifier = "==25.2.10" },
@@ -1338,6 +1425,7 @@ requires-dist = [
     { name = "pytest", specifier = "==8.3.5" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "python-dateutil", specifier = "==2.9.0.post0" },
+    { name = "python-docx", specifier = ">=1.2.0" },
     { name = "python-dotenv", specifier = "==1.1.0" },
     { name = "python-multipart", specifier = "==0.0.20" },
     { name = "pytz", specifier = "==2025.2" },
@@ -1356,6 +1444,7 @@ requires-dist = [
     { name = "tzdata", specifier = "==2025.2" },
     { name = "urllib3", specifier = "==2.5.0" },
     { name = "uvicorn", specifier = "==0.34.2" },
+    { name = "xhtml2pdf", specifier = ">=0.2.17" },
 ]
 
 [[package]]
@@ -1414,6 +1503,28 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
+]
+
+[[package]]
+name = "pycairo"
+version = "1.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/d9/1728840a22a4ef8a8f479b9156aa2943cd98c3907accd3849fb0d5f82bfd/pycairo-1.29.0.tar.gz", hash = "sha256:f3f7fde97325cae80224c09f12564ef58d0d0f655da0e3b040f5807bd5bd3142", size = 665871, upload-time = "2025-11-11T19:13:01.584Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/92/1b904087e831806a449502786d47d3a468e5edb8f65755f6bd88e8038e53/pycairo-1.29.0-cp311-cp311-win32.whl", hash = "sha256:12757ebfb304b645861283c20585c9204c3430671fad925419cba04844d6dfed", size = 751342, upload-time = "2025-11-11T19:11:37.386Z" },
+    { url = "https://files.pythonhosted.org/packages/db/09/a0ab6a246a7ede89e817d749a941df34f27a74bedf15551da51e86ae105e/pycairo-1.29.0-cp311-cp311-win_amd64.whl", hash = "sha256:3391532db03f9601c1cee9ebfa15b7d1db183c6020f3e75c1348cee16825934f", size = 845036, upload-time = "2025-11-11T19:11:43.408Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/b2/bf455454bac50baef553e7356d36b9d16e482403bf132cfb12960d2dc2e7/pycairo-1.29.0-cp311-cp311-win_arm64.whl", hash = "sha256:b69be8bb65c46b680771dc6a1a422b1cdd0cffb17be548f223e8cbbb6205567c", size = 694644, upload-time = "2025-11-11T19:11:48.599Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/28/6363087b9e60af031398a6ee5c248639eefc6cc742884fa2789411b1f73b/pycairo-1.29.0-cp312-cp312-win32.whl", hash = "sha256:91bcd7b5835764c616a615d9948a9afea29237b34d2ed013526807c3d79bb1d0", size = 751486, upload-time = "2025-11-11T19:11:54.451Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/d2/d146f1dd4ef81007686ac52231dd8f15ad54cf0aa432adaefc825475f286/pycairo-1.29.0-cp312-cp312-win_amd64.whl", hash = "sha256:3f01c3b5e49ef9411fff6bc7db1e765f542dc1c9cfed4542958a5afa3a8b8e76", size = 845383, upload-time = "2025-11-11T19:12:01.551Z" },
+    { url = "https://files.pythonhosted.org/packages/01/16/6e6f33bb79ec4a527c9e633915c16dc55a60be26b31118dbd0d5859e8c51/pycairo-1.29.0-cp312-cp312-win_arm64.whl", hash = "sha256:eafe3d2076f3533535ad4a361fa0754e0ee66b90e548a3a0f558fed00b1248f2", size = 694518, upload-time = "2025-11-11T19:12:06.561Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/21/3f477dc318dd4e84a5ae6301e67284199d7e5a2384f3063714041086b65d/pycairo-1.29.0-cp313-cp313-win32.whl", hash = "sha256:3eb382a4141591807073274522f7aecab9e8fa2f14feafd11ac03a13a58141d7", size = 750949, upload-time = "2025-11-11T19:12:12.198Z" },
+    { url = "https://files.pythonhosted.org/packages/43/34/7d27a333c558d6ac16dbc12a35061d389735e99e494ee4effa4ec6d99bed/pycairo-1.29.0-cp313-cp313-win_amd64.whl", hash = "sha256:91114e4b3fbf4287c2b0788f83e1f566ce031bda49cf1c3c3c19c3e986e95c38", size = 844149, upload-time = "2025-11-11T19:12:19.171Z" },
+    { url = "https://files.pythonhosted.org/packages/15/43/e782131e23df69e5c8e631a016ed84f94bbc4981bf6411079f57af730a23/pycairo-1.29.0-cp313-cp313-win_arm64.whl", hash = "sha256:09b7f69a5ff6881e151354ea092137b97b0b1f0b2ab4eb81c92a02cc4a08e335", size = 693595, upload-time = "2025-11-11T19:12:23.445Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/fa/87eaeeb9d53344c769839d7b2854db7ff2cd596211e00dd1b702eeb1838f/pycairo-1.29.0-cp314-cp314-win32.whl", hash = "sha256:69e2a7968a3fbb839736257bae153f547bca787113cc8d21e9e08ca4526e0b6b", size = 767198, upload-time = "2025-11-11T19:12:42.336Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/90/3564d0f64d0a00926ab863dc3c4a129b1065133128e96900772e1c4421f8/pycairo-1.29.0-cp314-cp314-win_amd64.whl", hash = "sha256:e91243437a21cc4c67c401eff4433eadc45745275fa3ade1a0d877e50ffb90da", size = 871579, upload-time = "2025-11-11T19:12:48.982Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/91/93632b6ba12ad69c61991e3208bde88486fdfc152be8cfdd13444e9bc650/pycairo-1.29.0-cp314-cp314-win_arm64.whl", hash = "sha256:b72200ea0e5f73ae4c788cd2028a750062221385eb0e6d8f1ecc714d0b4fdf82", size = 719537, upload-time = "2025-11-11T19:12:55.016Z" },
+    { url = "https://files.pythonhosted.org/packages/93/23/37053c039f8d3b9b5017af9bc64d27b680c48a898d48b72e6d6583cf0155/pycairo-1.29.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5e45fce6185f553e79e4ef1722b8e98e6cde9900dbc48cb2637a9ccba86f627a", size = 874015, upload-time = "2025-11-11T19:12:28.47Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/54/123f6239685f5f3f2edc123f1e38d2eefacebee18cf3c532d2f4bd51d0ef/pycairo-1.29.0-cp314-cp314t-win_arm64.whl", hash = "sha256:caba0837a4b40d47c8dfb0f24cccc12c7831e3dd450837f2a356c75f21ce5a15", size = 721404, upload-time = "2025-11-11T19:12:36.919Z" },
 ]
 
 [[package]]
@@ -1519,6 +1630,40 @@ wheels = [
 ]
 
 [[package]]
+name = "pyhanko"
+version = "0.34.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asn1crypto" },
+    { name = "cryptography" },
+    { name = "lxml" },
+    { name = "pyhanko-certvalidator" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/0e/32f538908f8b49c1e9d95c5098949f145110637331af520ea511fa8ff242/pyhanko-0.34.1.tar.gz", hash = "sha256:a4c288552f61607e031aa93f22f834759a3f5201107f80c2d5d266161ad11216", size = 8868035, upload-time = "2026-03-08T13:02:46.736Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/10/72bba8e5a51205acf32c4da594f5400ecebaf2684c70d393f4699ba3862e/pyhanko-0.34.1-py3-none-any.whl", hash = "sha256:5f46bb0230ca8e36069737eec602d7da779bfd61588281b91acd7002a5549a07", size = 471699, upload-time = "2026-03-08T13:02:44.983Z" },
+]
+
+[[package]]
+name = "pyhanko-certvalidator"
+version = "0.30.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asn1crypto" },
+    { name = "cryptography" },
+    { name = "oscrypto" },
+    { name = "requests" },
+    { name = "uritools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/9a/0fc4a955bc432eb8598ba3481e19df4706cace594c9fbe760587ea3dfd1c/pyhanko_certvalidator-0.30.1.tar.gz", hash = "sha256:a37e7b11a4afc85594916abdf64b16c42e8b61cd3fa73a53652d16ac8958df18", size = 583602, upload-time = "2026-03-08T13:06:34.713Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/5b/b536e76b14381f36b5d1d222f7b263616881cd94d1c0ffd23f2e3e9dc358/pyhanko_certvalidator-0.30.1-py3-none-any.whl", hash = "sha256:f9912295f2d6bd99fdf68e1740b5163a27b135c8dd41d992a630066393ba0a3b", size = 110640, upload-time = "2026-03-08T13:06:33.115Z" },
+]
+
+[[package]]
 name = "pyjwt"
 version = "2.10.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1530,6 +1675,15 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pypdf"
+version = "6.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/a3/e705b0805212b663a4c27b861c8a603dba0f8b4bb281f96f8e746576a50d/pypdf-6.8.0.tar.gz", hash = "sha256:cb7eaeaa4133ce76f762184069a854e03f4d9a08568f0e0623f7ea810407833b", size = 5307831, upload-time = "2026-03-09T13:37:40.591Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/ec/4ccf3bb86b1afe5d7176e1c8abcdbf22b53dd682ec2eda50e1caadcf6846/pypdf-6.8.0-py3-none-any.whl", hash = "sha256:2a025080a8dd73f48123c89c57174a5ff3806c71763ee4e49572dc90454943c7", size = 332177, upload-time = "2026-03-09T13:37:38.774Z" },
 ]
 
 [[package]]
@@ -1570,6 +1724,76 @@ wheels = [
 ]
 
 [[package]]
+name = "python-bidi"
+version = "0.6.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/e3/c0c8bf6fca79ac946a28d57f116e3b9e5b10a4469b6f70bf73f3744c49bf/python_bidi-0.6.7.tar.gz", hash = "sha256:c10065081c0e137975de5d9ba2ff2306286dbf5e0c586d4d5aec87c856239b41", size = 45503, upload-time = "2025-10-22T09:52:49.624Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/de/c30a13ad95239507af472a5fc2cadd2e5e172055068f12ac39b37922c7f8/python_bidi-0.6.7-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a8892a7da0f617135fe9c92dc7070d13a0f96ab3081f9db7ff5b172a3905bd78", size = 274420, upload-time = "2025-10-22T09:51:58.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/9f/be5efef7eea5f1e2a6415c4052a988f594dcf5a11a15103f2718d324a35b/python_bidi-0.6.7-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:06650a164e63e94dc8a291cc9d415b4027cb1cce125bc9b02dac0f34d535ed47", size = 264586, upload-time = "2025-10-22T09:51:49.255Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ec/2c374b6de35870817ffb3512c0666ea8c3794ef923b5586c69451e0e5395/python_bidi-0.6.7-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6df7be07af867ec1d121c92ea827efad4d77b25457c06eeab477b601e82b2340", size = 293672, upload-time = "2025-10-22T09:50:58.504Z" },
+    { url = "https://files.pythonhosted.org/packages/29/1a/722d7d7128bdc9a530351a0d2fdf2ff5f4af66a865a6bca925f99832e2cc/python_bidi-0.6.7-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:73a88dc333efc42281bd800d5182c8625c6e11d109fc183fe3d7a11d48ab1150", size = 302643, upload-time = "2025-10-22T09:51:06.419Z" },
+    { url = "https://files.pythonhosted.org/packages/24/d7/5b9b593dd58fc745233d8476e9f4e0edd437547c78c58340619868470349/python_bidi-0.6.7-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f24189dc3aea3a0a94391a047076e1014306b39ba17d7a38ebab510553cd1a97", size = 441692, upload-time = "2025-10-22T09:51:15.39Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b9/16e7a1db5f022da6654e89875d231ec2e044d42ef7b635feeff61cee564c/python_bidi-0.6.7-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a507fe6928a27a308e04ebf2065719b7850d1bf9ff1924f4e601ef77758812bd", size = 326933, upload-time = "2025-10-22T09:51:23.631Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/a6/45aaec301292c6a07a9cc3168f5d1a92c8adc2ef36a3cd1f227b9caa980c/python_bidi-0.6.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fbbffb948a32f9783d1a28bc0c53616f0a76736ed1e7c1d62e3e99a8dfaab869", size = 302034, upload-time = "2025-10-22T09:51:41.347Z" },
+    { url = "https://files.pythonhosted.org/packages/71/a3/7e42cce6e153c21b4e5cc96d429a5910909823f6fedd174b64ff67bc76a7/python_bidi-0.6.7-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f7e507e1e798ebca77ddc9774fd405107833315ad802cfdaa1ab07b6d9154fc8", size = 315738, upload-time = "2025-10-22T09:51:33.409Z" },
+    { url = "https://files.pythonhosted.org/packages/43/7c/a5e4c0acc8e6ca61953b4add0576f0483f63b809b5389154e5da13927b0b/python_bidi-0.6.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:849a57d39feaf897955d0b19bbf4796bea53d1bcdf83b82e0a7b059167eb2049", size = 473968, upload-time = "2025-10-22T09:52:07.624Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/aa/a18bc3cbab7a0e598cbe7b89f2c0913aedcc66dcafce9a4c357465c87859/python_bidi-0.6.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:5ebc19f24e65a1f5c472e26d88e78b9d316e293bc6f205f32de4c4e99276336e", size = 567038, upload-time = "2025-10-22T09:52:18.594Z" },
+    { url = "https://files.pythonhosted.org/packages/92/46/fc6c54a8b5bfbee50e650f885ddef4f8c4f92880467ea0bc2bf133747048/python_bidi-0.6.7-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:24388c77cb00b8aa0f9c84beb7e3e523a3dac4f786ece64a1d8175a07b24da72", size = 493970, upload-time = "2025-10-22T09:52:29.815Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/2c15f5b938b2e087e4e950cc14dcead5bedbaabfc6c576dac15739bc0c91/python_bidi-0.6.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:19737d217088ef27014f98eac1827c5913e6fb1dea96332ed84ede61791070d9", size = 465161, upload-time = "2025-10-22T09:52:40.517Z" },
+    { url = "https://files.pythonhosted.org/packages/56/d7/73a70a1fb819152485521b8dfe627e14ba9d3d5a65213244ab099adf3600/python_bidi-0.6.7-cp311-cp311-win32.whl", hash = "sha256:95c9de7ebc55ffb777548f2ecaf4b96b0fa0c92f42bf4d897b9f4cd164ec7394", size = 157033, upload-time = "2025-10-22T09:52:59.228Z" },
+    { url = "https://files.pythonhosted.org/packages/68/84/06999dc54ea047fe33209af7150df4202ab7ad52deeb66b2c2040ac07884/python_bidi-0.6.7-cp311-cp311-win_amd64.whl", hash = "sha256:898db0ea3e4aaa95b7fecba02a7560dfbf368f9d85053f2875f6d610c4d4ec2c", size = 161282, upload-time = "2025-10-22T09:52:51.467Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/03/5b2f3e73501d0f41ebc2b075b49473047c6cdfc3465cf890263fc69e3915/python_bidi-0.6.7-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:11c51579e01f768446a7e13a0059fea1530936a707abcbeaad9467a55cb16073", size = 272536, upload-time = "2025-10-22T09:51:59.721Z" },
+    { url = "https://files.pythonhosted.org/packages/31/77/c6048e938a73e5a7c6fa3d5e3627a5961109daa728c2e7d050567cecdc26/python_bidi-0.6.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:47deaada8949af3a790f2cd73b613f9bfa153b4c9450f91c44a60c3109a81f73", size = 263258, upload-time = "2025-10-22T09:51:50.328Z" },
+    { url = "https://files.pythonhosted.org/packages/57/56/ed4dc501cab7de70ce35cd435c86278e4eb1caf238c80bc72297767c9219/python_bidi-0.6.7-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b38ddfab41d10e780edb431edc30aec89bee4ce43d718e3896e99f33dae5c1d3", size = 292700, upload-time = "2025-10-22T09:50:59.628Z" },
+    { url = "https://files.pythonhosted.org/packages/77/6a/1bf06d7544c940ffddd97cd0e02c55348a92163c5495fa18e34217dfbebe/python_bidi-0.6.7-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2a93b0394cc684d64356b0475858c116f1e335ffbaba388db93bf47307deadfa", size = 300881, upload-time = "2025-10-22T09:51:07.507Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1d/ce7577a8f50291c06e94f651ac5de0d1678fc2642af26a5dad9901a0244f/python_bidi-0.6.7-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ec1694134961b71ac05241ac989b49ccf08e232b5834d5fc46f8a7c3bb1c13a9", size = 439125, upload-time = "2025-10-22T09:51:16.559Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/87/4cf6dcd58e22f0fd904e7a161c6b73a5f9d17d4d49073fcb089ba62f1469/python_bidi-0.6.7-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8047c33b85f7790474a1f488bef95689f049976a4e1c6f213a8d075d180a93e4", size = 325816, upload-time = "2025-10-22T09:51:25.12Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0a/4028a088e29ce8f1673e85ec9f64204fc368355c3207e6a71619c2b4579a/python_bidi-0.6.7-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9d9de35eb5987da27dd81e371c52142dd8e924bd61c1006003071ea05a735587", size = 300550, upload-time = "2025-10-22T09:51:42.739Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/05/cac15eba462d5a2407ac4ef1c792c45a948652b00c6bd81eaab3834a62d2/python_bidi-0.6.7-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a99d898ad1a399d9c8cab5561b3667fd24f4385820ac90c3340aa637aa5adfc9", size = 313017, upload-time = "2025-10-22T09:51:34.905Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/b1/3ba91b9ea60fa54a9aa730a5fe432bd73095d55be371244584fc6818eae1/python_bidi-0.6.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5debaab33562fdfc79ffdbd8d9c51cf07b8529de0e889d8cd145d78137aab21e", size = 472798, upload-time = "2025-10-22T09:52:09.079Z" },
+    { url = "https://files.pythonhosted.org/packages/50/40/4bf5fb7255e35c218174f322a4d4c80b63b2604d73adc6e32f843e700824/python_bidi-0.6.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:c11c62a3cdb9d1426b1536de9e3446cb09c7d025bd4df125275cae221f214899", size = 565234, upload-time = "2025-10-22T09:52:19.703Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/81/ad23fb85bff69d0a25729cd3834254b87c3c7caa93d657c8f8edcbed08f6/python_bidi-0.6.7-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:6c051f2d28ca542092d01da8b5fe110fb6191ff58d298a54a93dc183bece63bf", size = 491844, upload-time = "2025-10-22T09:52:31.216Z" },
+    { url = "https://files.pythonhosted.org/packages/65/85/103baaf142b2838f583b71904a2454fa31bd2a912ff505c25874f45d6c3e/python_bidi-0.6.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:95867a07c5dee0ea2340fe1d0e4f6d9f5c5687d473193b6ee6f86fa44aac45d1", size = 463753, upload-time = "2025-10-22T09:52:41.943Z" },
+    { url = "https://files.pythonhosted.org/packages/54/c3/6a5c3b9f42a6b188430c83a7e70a76bc7c0db3354302fce7c8ed94a0c062/python_bidi-0.6.7-cp312-cp312-win32.whl", hash = "sha256:4c73cd980d45bb967799c7f0fc98ea93ae3d65b21ef2ba6abef6a057720bf483", size = 155820, upload-time = "2025-10-22T09:53:00.254Z" },
+    { url = "https://files.pythonhosted.org/packages/45/c4/683216398ee3abf6b9bb0f26ae15c696fabbe36468ba26d5271f0c11b343/python_bidi-0.6.7-cp312-cp312-win_amd64.whl", hash = "sha256:d524a4ba765bae9b950706472a77a887a525ed21144fe4b41f6190f6e57caa2c", size = 159966, upload-time = "2025-10-22T09:52:52.547Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a5/8ad0a448d42fd5d01dd127c1dc5ab974a8ea6e20305ac89a3356dacd3bdf/python_bidi-0.6.7-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1c061207212cd1db27bf6140b96dcd0536246f1e13e99bb5d03f4632f8e2ad7f", size = 272129, upload-time = "2025-10-22T09:52:00.761Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/c0/a13981fc0427a0d35e96fc4e31fbb0f981b28d0ce08416f98f42d51ea3bc/python_bidi-0.6.7-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a2eb8fca918c7381531035c3aae31c29a1c1300ab8a63cad1ec3a71331096c78", size = 263174, upload-time = "2025-10-22T09:51:51.401Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/32/74034239d0bca32c315cac5c3ec07ef8eb44fa0e8cea1585cad85f5b8651/python_bidi-0.6.7-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:414004fe9cba33d288ff4a04e1c9afe6a737f440595d01b5bbed00d750296bbd", size = 292496, upload-time = "2025-10-22T09:51:00.708Z" },
+    { url = "https://files.pythonhosted.org/packages/83/fa/d6c853ed2668b1c12d66e71d4f843d0710d1ccaecc17ce09b35d2b1382a7/python_bidi-0.6.7-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5013ba963e9da606c4c03958cc737ebd5f8b9b8404bd71ab0d580048c746f875", size = 300727, upload-time = "2025-10-22T09:51:09.152Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8d/55685bddfc1fbfa6e28e1c0be7df4023e504de7d2ac1355a3fa610836bc1/python_bidi-0.6.7-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ad5f0847da00687f52d2b81828e8d887bdea9eb8686a9841024ea7a0e153028e", size = 438823, upload-time = "2025-10-22T09:51:17.844Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/54/db9e70443f89e3ec6fa70dcd16809c3656d1efe7946076dcd59832f722df/python_bidi-0.6.7-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26a8fe0d532b966708fc5f8aea0602107fde4745a8a5ae961edd3cf02e807d07", size = 325721, upload-time = "2025-10-22T09:51:26.132Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c5/98ac9c00f17240f9114c756791f0cd9ba59a5d4b5d84fd1a6d0d50604e82/python_bidi-0.6.7-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6323e943c7672b271ad9575a2232508f17e87e81a78d7d10d6e93040e210eddf", size = 300493, upload-time = "2025-10-22T09:51:43.783Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/cb/382538dd7c656eb50408802b9a9466dbd3432bea059410e65a6c14bc79f9/python_bidi-0.6.7-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:349b89c3110bd25aa56d79418239ca4785d4bcc7a596e63bb996a9696fc6a907", size = 312889, upload-time = "2025-10-22T09:51:36.011Z" },
+    { url = "https://files.pythonhosted.org/packages/50/8d/dbc784cecd9b2950ba99c8fef0387ae588837e4e2bfd543be191d18bf9f6/python_bidi-0.6.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e7cad66317f12f0fd755fe41ee7c6b06531d2189a9048a8f37addb5109f7e3e3", size = 472798, upload-time = "2025-10-22T09:52:10.446Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e6/398d59075265717d2950622ede1d366aff88ffcaa67a30b85709dea72206/python_bidi-0.6.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:49639743f1230648fd4fb47547f8a48ada9c5ca1426b17ac08e3be607c65394c", size = 564974, upload-time = "2025-10-22T09:52:22.416Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/8e/2b939be0651bc2b69c234dc700723a26b93611d5bdd06b253d67d9da3557/python_bidi-0.6.7-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4636d572b357ab9f313c5340915c1cf51e3e54dd069351e02b6b76577fd1a854", size = 491711, upload-time = "2025-10-22T09:52:32.322Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/05/f53739ab2ce2eee0c855479a31b64933f6ff6164f3ddc611d04e4b79d922/python_bidi-0.6.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d7310312a68fdb1a8249cf114acb5435aa6b6a958b15810f053c1df5f98476e4", size = 463536, upload-time = "2025-10-22T09:52:43.142Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c6/800899e2764f723c2ea9172eabcc1a31ffb8b4bb71ea5869158fd83bd437/python_bidi-0.6.7-cp313-cp313-win32.whl", hash = "sha256:ec985386bc3cd54155f2ef0434fccbfd743617ed6fc1a84dae2ab1de6062e0c6", size = 155786, upload-time = "2025-10-22T09:53:01.357Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ba/a811c12c1a4b8fa7c0c0963d92c042284c2049b1586615af6b1774b786d9/python_bidi-0.6.7-cp313-cp313-win_amd64.whl", hash = "sha256:f57726b5a90d818625e6996f5116971b7a4ceb888832337d0e2cf43d1c362a90", size = 159863, upload-time = "2025-10-22T09:52:53.537Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/cda302126e878be162bf183eb0bd6dc47ca3e680fb52111e49c62a8ea1eb/python_bidi-0.6.7-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b0bee27fb596a0f518369c275a965d0448c39a0730e53a030b311bb10562d4d5", size = 271899, upload-time = "2025-10-22T09:52:01.758Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/4b/9c15ca0fe795a5c55a39daa391524ac74e26d9187493632d455257771023/python_bidi-0.6.7-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6c19ab378fefb1f09623f583fcfa12ed42369a998ddfbd39c40908397243c56b", size = 262235, upload-time = "2025-10-22T09:51:52.379Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/5e/25b25be64bff05272aa28d8bef2fbbad8415db3159a41703eb2e63dc9824/python_bidi-0.6.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:630cee960ba9e3016f95a8e6f725a621ddeff6fd287839f5693ccfab3f3a9b5c", size = 471983, upload-time = "2025-10-22T09:52:12.182Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/78/a9363f5da1b10d9211514b96ea47ecc95c797ed5ac566684bfece0666082/python_bidi-0.6.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:0dbb4bbae212cca5bcf6e522fe8f572aff7d62544557734c2f810ded844d9eea", size = 565016, upload-time = "2025-10-22T09:52:23.515Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/ed/37dcb7d3dc250ecdff8120b026c37fcdbeada4111e4d7148c053180bcf54/python_bidi-0.6.7-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:1dd0a5ec0d8710905cebb4c9e5018aa8464395a33cb32a3a6c2a951bf1984fe5", size = 491180, upload-time = "2025-10-22T09:52:33.505Z" },
+    { url = "https://files.pythonhosted.org/packages/40/a3/50d1f6060a7a500768768f5f8735cb68deba36391248dbf13d5d2c9c0885/python_bidi-0.6.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4ea928c31c7364098f853f122868f6f2155d6840661f7ea8b2ccfdf6084eb9f4", size = 463126, upload-time = "2025-10-22T09:52:44.28Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/47/712cd7d1068795c57fdf6c4acca00716688aa8b4e353b30de2ed8f599fd6/python_bidi-0.6.7-cp314-cp314-win32.whl", hash = "sha256:f7c055a50d068b3a924bd33a327646346839f55bcb762a26ec3fde8ea5d40564", size = 155793, upload-time = "2025-10-22T09:53:02.7Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/e8/1f86bf699b20220578351f9b7b635ed8b6e84dd51ad3cca08b89513ae971/python_bidi-0.6.7-cp314-cp314-win_amd64.whl", hash = "sha256:8a17631e3e691eec4ae6a370f7b035cf0a5767f4457bd615d11728c23df72e43", size = 159821, upload-time = "2025-10-22T09:52:54.95Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4e/6135798d84b62eea70c0f9435301c2a4ba854e87be93a3fcd1d935266d24/python_bidi-0.6.7-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c9a679b24f5c6f366a0dec75745e1abeae2f597f033d0d54c74cbe62e7e6ae28", size = 276275, upload-time = "2025-10-22T09:52:05.078Z" },
+    { url = "https://files.pythonhosted.org/packages/74/83/2123596d43e552af9e2806e361646fa579f34a1d1e9e2c1707a0ab6a02dd/python_bidi-0.6.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:05fe5971110013610f0db40505d0b204edc756e92eafac1372a464f8b9162b11", size = 266951, upload-time = "2025-10-22T09:51:56.216Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/8c/8d1e1501717227a6d52fc7b9c47a3de61486b024fbdd4821bfad724c0699/python_bidi-0.6.7-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:17572944e6d8fb616d111fc702c759da2bf7cedab85a3e4fa2af0c9eb95ed438", size = 295745, upload-time = "2025-10-22T09:51:04.438Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ff/ef04e7f9067c2c5d862b9f8d9a192486c500c8aa295f0fb756c25ab47fc8/python_bidi-0.6.7-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3b63d19f3f56ff7f99bce5ca9ef8c811dbf0f509d8e84c1bc06105ed26a49528", size = 304123, upload-time = "2025-10-22T09:51:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/be/72/b973895e257a7d4cc8365ab094612f6ee885df863a4964d8865b9f534b67/python_bidi-0.6.7-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f1350033431d75be749273236dcfc808e54404cd6ece6204cdb1bc4ccc163455", size = 442484, upload-time = "2025-10-22T09:51:21.575Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/1a/68ca9d10bc309828e8cdb2d57a30dd7e5753ac8520c8d7a0322daeb9eef7/python_bidi-0.6.7-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1c5fb99f774748de283fadf915106f130b74be1bade934b7f73a7a8488b95da1", size = 329149, upload-time = "2025-10-22T09:51:31.232Z" },
+    { url = "https://files.pythonhosted.org/packages/03/40/ab450c06167a7de596d99b1ba5cee2c605b3ff184baccf08210ede706b1b/python_bidi-0.6.7-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2d28e2bdcadf5b6161bb4ee9313ce41eac746ba57e744168bf723a415a11af05", size = 303529, upload-time = "2025-10-22T09:51:46.997Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c5/585b5c413e3b77a32500fb877ea30aa23c45a6064dbd7fe77d87b72cd90b/python_bidi-0.6.7-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c3777ae3e088e94df854fbcbd8d59f9239b74aac036cb6bbd19f8035c8e42478", size = 317753, upload-time = "2025-10-22T09:51:39.272Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/05/b7b4b447890d614ccb40633f4d65f334bcf9fe3ad13be33aaa54dcbc34f3/python_bidi-0.6.7-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:77bb4cbadf4121db395189065c58c9dd5d1950257cc1983004e6df4a3e2f97ad", size = 476054, upload-time = "2025-10-22T09:52:15.856Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/94/64f6d2c09c4426918345b54ca8902f94b663eadd744c9dd89070f546c9bc/python_bidi-0.6.7-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:f1fe71c203f66bc169a393964d5702f9251cfd4d70279cb6453fdd42bd2e675f", size = 568365, upload-time = "2025-10-22T09:52:27.556Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d2/c39a6b82aa0fcedac7cbe6078b78bb9089b43d903f8e00859e42b504bb8e/python_bidi-0.6.7-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:d87ed09e5c9b6d2648e8856a4e556147b9d3cd4d63905fa664dd6706bc414256", size = 495292, upload-time = "2025-10-22T09:52:38.306Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/8d/a80f37ab92118e305d7b574306553599f81534c50b4eb23ef34ebe09c09c/python_bidi-0.6.7-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:766d5f5a686eb99b53168a7bdfb338035931a609bdbbcb537cef9e050a86f359", size = 467159, upload-time = "2025-10-22T09:52:48.603Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1579,6 +1803,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-docx"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/f7/eddfe33871520adab45aaa1a71f0402a2252050c14c7e3009446c8f4701c/python_docx-1.2.0.tar.gz", hash = "sha256:7bc9d7b7d8a69c9c02ca09216118c86552704edc23bac179283f2e38f86220ce", size = 5723256, upload-time = "2025-06-16T20:46:27.921Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/00/1e03a4989fa5795da308cd774f05b704ace555a70f9bf9d3be057b680bcf/python_docx-1.2.0-py3-none-any.whl", hash = "sha256:3fd478f3250fbbbfd3b94fe1e985955737c145627498896a8a6bf81f4baf66c7", size = 252987, upload-time = "2025-06-16T20:46:22.506Z" },
 ]
 
 [[package]]
@@ -1723,6 +1960,19 @@ wheels = [
 ]
 
 [[package]]
+name = "reportlab"
+version = "4.4.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "charset-normalizer" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/57/28bfbf0a775b618b6e4d854ef8dd3f5c8988e5d614d8898703502a35f61c/reportlab-4.4.10.tar.gz", hash = "sha256:5cbbb34ac3546039d0086deb2938cdec06b12da3cdb836e813258eb33cd28487", size = 3714962, upload-time = "2026-02-12T10:45:21.325Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/2e/e1798b8b248e1517e74c6cdf10dd6edd485044e7edf46b5f11ffcc5a0add/reportlab-4.4.10-py3-none-any.whl", hash = "sha256:5abc815746ae2bc44e7ff25db96814f921349ca814c992c7eac3c26029bf7c24", size = 1955400, upload-time = "2026-02-12T10:45:18.828Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1735,6 +1985,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "rlpycairo"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "freetype-py" },
+    { name = "pycairo" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/24/09b18821e06de45394d34dda706d34169db6bddd6a403346caa3496b3668/rlpycairo-0.4.0.tar.gz", hash = "sha256:07c2c3c47828e83d9c09657a54ecbcd1a97aac9dc199780234456d3473faadc7", size = 7692, upload-time = "2025-08-15T12:25:22.761Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/00/d26b61e82163a59334e9f2ae31ba95ac01922da3792f090e11762d4422e8/rlpycairo-0.4.0-py3-none-any.whl", hash = "sha256:3ce83825d5761c03bc3571c7db12a336ad51417e63189e3512d11b8922576aa9", size = 7558, upload-time = "2025-08-15T12:24:52.544Z" },
 ]
 
 [[package]]
@@ -1798,6 +2061,22 @@ wheels = [
 ]
 
 [[package]]
+name = "svglib"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cssselect2" },
+    { name = "lxml" },
+    { name = "reportlab" },
+    { name = "rlpycairo" },
+    { name = "tinycss2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/16/6b5f9f8c8b18d9ab5112d11e2d6c40c965e3d7ab2948b744685fe6d2f9f5/svglib-1.6.0.tar.gz", hash = "sha256:4c38a274a744ef0d1677f55d5d62fc0fb798819f813e52872a796e615741733d", size = 1318276, upload-time = "2025-09-25T09:48:37.839Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/93/01273a1b8d8454d45f2e18b3d6098c7be13a0864a55fbd0ebda7815c201a/svglib-1.6.0-py3-none-any.whl", hash = "sha256:9aea8e2e81cbbf9c844460e4c7dc90e0a06aea7983bc201975ccd279d7b2d194", size = 39163, upload-time = "2025-09-25T09:48:35.927Z" },
+]
+
+[[package]]
 name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1816,6 +2095,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036, upload-time = "2025-04-02T08:25:09.966Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248, upload-time = "2025-04-02T08:25:07.678Z" },
+]
+
+[[package]]
+name = "tinycss2"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl", hash = "sha256:3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661", size = 28404, upload-time = "2025-11-23T10:29:08.676Z" },
 ]
 
 [[package]]
@@ -1861,6 +2152,27 @@ wheels = [
 ]
 
 [[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
+]
+
+[[package]]
+name = "uritools"
+version = "6.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/f7/6651d145bedd535a5bdd6dad108329ec1fec89d38ec611f8d98834eb5378/uritools-6.0.1.tar.gz", hash = "sha256:2f9e9cb954e7877232b2c863f724a44a06eb98d9c7ebdd69914876e9487b94f8", size = 22857, upload-time = "2025-12-21T18:58:54.446Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/d7/e1542857c3f7615a1a9afa6b602b87cb5a33885db41c686aa7bf5092d4f0/uritools-6.0.1-py3-none-any.whl", hash = "sha256:d9507b82206c857d2f93d8fcc84f3b05ae4174096761102be690aa76a360cc1b", size = 10466, upload-time = "2025-12-21T18:58:52.903Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1880,6 +2192,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a6/ae/9bbb19b9e1c450cf9ecaef06463e40234d98d95bf572fab11b4f19ae5ded/uvicorn-0.34.2.tar.gz", hash = "sha256:0e929828f6186353a80b58ea719861d2629d766293b6d19baf086ba31d4f3328", size = 76815, upload-time = "2025-04-19T06:02:50.101Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/4b/4cef6ce21a2aaca9d852a6e84ef4f135d99fcd74fa75105e2fc0c8308acd/uvicorn-0.34.2-py3-none-any.whl", hash = "sha256:deb49af569084536d269fe0a6d67e3754f104cf03aba7c11c40f01aadf33c403", size = 62483, upload-time = "2025-04-19T06:02:48.42Z" },
+]
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
 ]
 
 [[package]]
@@ -1922,6 +2243,26 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
     { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "xhtml2pdf"
+version = "0.2.17"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "arabic-reshaper" },
+    { name = "html5lib" },
+    { name = "pillow" },
+    { name = "pyhanko" },
+    { name = "pyhanko-certvalidator" },
+    { name = "pypdf" },
+    { name = "python-bidi" },
+    { name = "reportlab" },
+    { name = "svglib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/9a/3b29831d8617ecbcf0b0aaa2b3e1b24f3fd1bbd204678ae86e9fee2f4239/xhtml2pdf-0.2.17.tar.gz", hash = "sha256:09ddbc31aa0e38a16f2f3cb73be89af5f7c968c17a564afdd685d280e39c526d", size = 139727, upload-time = "2025-02-23T23:17:02.484Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/ca/d53764f0534ff857239595f090f4cb83b599d226cc326c7de5eb3d802715/xhtml2pdf-0.2.17-py3-none-any.whl", hash = "sha256:61a7ecac829fed518f7dbcb916e9d56bea6e521e02e54644b3d0ca33f0658315", size = 125349, upload-time = "2025-02-24T20:44:42.604Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- 新增 python-docx、xhtml2pdf、ebooklib 依赖以支持 DOCX、PDF、EPUB 导出
- 基于 _intermediate.json 实现统一导出逻辑，避免二次解析导致结构丢失
- 导出模块支持按 Markdown 标题语法重建结构，确保 DOCX 标题、EPUB 目录、PDF 中文显示正确
- 新增预览脚本 preview_export_outputs.py，可快速检查导出文件的结构与内容
- 在主流程中集成导出选项，翻译完成后可选择导出为 DOCX/PDF/EPUB/XLSX 格式